### PR TITLE
<996 License> is misleading, it should be <Anti 996 License>

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Copyright (c) <year> <copyright holders>
 
-996 License Version 1.0 (Draft)
+Anti 996 License Version 1.0 (Draft)
 
 Permission is hereby granted to any individual or legal entity obtaining a copy
 of this licensed work (including the source code, documentation and/or related

--- a/LICENSE_CN_EN
+++ b/LICENSE_CN_EN
@@ -30,7 +30,7 @@
 
 Copyright (c) <year> <copyright holders>
 
-996 License Version 1.0 (Draft)
+Anti 996 License Version 1.0 (Draft)
 
 Permission is hereby granted to any individual or legal entity obtaining a copy
 of this licensed work (including the source code, documentation and/or related


### PR DESCRIPTION
In the chinese version of Anti-996-License, it's name is ```*反*996许可证```, but the english version of this license was named as ```996 License```, this is misleading, I think ```996 License``` should be corrected to ```Anti 996 License```.

Same [pull request](https://github.com/996icu/996.ICU/pull/25024) was opened to [996icu/996.ICU](https://github.com/996icu/996.ICU).